### PR TITLE
Fix slash

### DIFF
--- a/03_MapReduce_using_MRJob_1/03_MapReduce_using_mrjob_1.ipynb
+++ b/03_MapReduce_using_MRJob_1/03_MapReduce_using_mrjob_1.ipynb
@@ -1392,7 +1392,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/03_MapReduce_using_MRJob_1/03_MapReduce_using_mrjob_1.ipynb
+++ b/03_MapReduce_using_MRJob_1/03_MapReduce_using_mrjob_1.ipynb
@@ -1177,7 +1177,7 @@
     "&& python3 mr-jobs/2.3_train_test_splitting.py ../data/job-data/* \\\n",
     "--output-dir mr-output/test \\\n",
     "--test_size 0.3 \\\n",
-    "--split test \\"
+    "--split test"
    ]
   },
   {
@@ -1392,7 +1392,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For the local run under "Creating a reproducible train/test split", there is an extra slash that breaks the `&& python3 mr-jobs/2.3_train_test_splitting.py` run. I delete it here. I discussed this in-person with Jake who saw the error on his machine too.